### PR TITLE
Add query hint support 

### DIFF
--- a/src/main/java/com/eharmony/pho/hbase/translator/PhoenixHBaseQueryTranslator.java
+++ b/src/main/java/com/eharmony/pho/hbase/translator/PhoenixHBaseQueryTranslator.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.base.Strings;
 import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
@@ -85,13 +86,14 @@ public class PhoenixHBaseQueryTranslator extends AbstractQueryTranslator<String,
         Orderings orders = query.getOrder();
         Integer maxResults = query.getMaxResults();
         Class<T> entityClass = query.getEntityClass();
-
+        Joiner spaceJoiner = Joiner.on(" ");
         String projection = PROJECTION_ALL;
         if (CollectionUtils.isNotEmpty(fields)) {
             projection = Joiner.on(", ").join(
                     entityPropertiesResolver.resolveEntityMappingPropertyNames(fields, entityClass));
         }
-        Joiner spaceJoiner = Joiner.on(" ");
+        //Add query hint if available
+        projection = Strings.isNullOrEmpty(query.getQueryHint()) ? projection : spaceJoiner.join(query.getQueryHint(), PROJECTION_ALL);
         String queryString = spaceJoiner.join(new String[] { SELECT, projection, PhoenixHBaseClauses.FROM.symbol(),
                 entityResolver.resolve(entityClass) });
 

--- a/src/main/java/com/eharmony/pho/query/QuerySelect.java
+++ b/src/main/java/com/eharmony/pho/query/QuerySelect.java
@@ -66,4 +66,11 @@ public interface QuerySelect<T, R> {
      */
     public QueryOperationType getQueryOperationType();
 
+    /**
+     * Getter method for Query Hint
+     *
+     * @return <code>String</code>
+     */
+    public String getQueryHint();
+
 }

--- a/src/main/java/com/eharmony/pho/query/QuerySelectImpl.java
+++ b/src/main/java/com/eharmony/pho/query/QuerySelectImpl.java
@@ -22,9 +22,10 @@ public class QuerySelectImpl<T, R> implements QuerySelect<T, R> {
     private final Integer maxResults;
     private final List<String> returnFields;
     private final QueryOperationType queryOperationType;
+    private final String queryHint;
 
     public QuerySelectImpl(Class<T> entityClass, Class<R> returnType, Criterion criteria, Orderings orderings,
-            Integer maxResults, List<String> returnFields, QueryOperationType queryOperationType) {
+            Integer maxResults, List<String> returnFields, QueryOperationType queryOperationType, String queryHint) {
         this.entityClass = entityClass;
         this.returnType = returnType;
         this.criteria = criteria;
@@ -32,11 +33,17 @@ public class QuerySelectImpl<T, R> implements QuerySelect<T, R> {
         this.orderings = orderings;
         this.maxResults = maxResults;
         this.queryOperationType = queryOperationType;
+        this.queryHint = queryHint;
     }
 
     @Override
     public QueryOperationType getQueryOperationType() {
         return queryOperationType;
+    }
+
+    @Override
+    public String getQueryHint() {
+        return queryHint;
     }
 
     /*

--- a/src/main/java/com/eharmony/pho/query/builder/QueryBuilder.java
+++ b/src/main/java/com/eharmony/pho/query/builder/QueryBuilder.java
@@ -30,6 +30,7 @@ public class QueryBuilder<T, R> {
     private Integer maxResults;
     private List<String> returnFields = Collections.emptyList();
     private QueryOperationType queryOperationType;
+    private String queryHint;
 
     public QueryBuilder(Class<T> entityClass, Class<R> returnType) {
         this.entityClass = entityClass;
@@ -126,6 +127,11 @@ public class QueryBuilder<T, R> {
         return this;
     }
 
+    public QueryBuilder<T, R> setQueryHint(String queryHint) {
+        this.queryHint = queryHint;
+        return this;
+    }
+
     public QuerySelect<T, R> build() {
         // if criteria.size == 0, rootCriterion = null
         Criterion rootCriterion = null;
@@ -135,7 +141,7 @@ public class QueryBuilder<T, R> {
             rootCriterion = Restrictions.and(criteria.toArray(new Criterion[criteria.size()]));
         }
         return new QuerySelectImpl<T, R>(entityClass, returnType, rootCriterion, orderings, maxResults, returnFields,
-                queryOperationType);
+                queryOperationType, queryHint);
     }
 
     @Override


### PR DESCRIPTION
When queries use secondary indexes an extra RPC call is issued from client. By providing explicit query hints we can avoid this which results in dramatic increase in performance.